### PR TITLE
Add Docker support for running app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.next
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use Node.js 18 for building the Next.js application
+FROM node:18-alpine AS builder
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Build the application
+COPY . .
+RUN npm run build
+
+# Production image
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Copy build artifacts and dependencies from builder stage
+COPY --from=builder /app .
+
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# youtube-filter
+
+A simple Next.js application for filtering YouTube videos.
+
+## Running with Docker
+
+Build the image:
+
+```bash
+docker build -t youtube-filter .
+```
+
+Run the container:
+
+```bash
+docker run -p 3000:3000 youtube-filter
+```
+
+The application will be available at http://localhost:3000.


### PR DESCRIPTION
## Summary
- add Dockerfile with multi-stage build to run the Next.js app
- document container usage in README
- ignore build artifacts in Docker context

## Testing
- `npm test`
- `docker build -t youtube-filter .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a774f03e8c8325a8c1c477f6085fdd