### PR TITLE
Add like and duration filters

### DIFF
--- a/pages/api/videos.js
+++ b/pages/api/videos.js
@@ -157,6 +157,7 @@ export default async function handler(req, res) {
       return {
         Title: sn.title || '',
         Views: Number(st.viewCount || 0),
+        Likes: Number(st.likeCount || 0),
         Published: sn.publishedAt || '',
         Duration: v.contentDetails?.duration || '',
         'Video URL': `https://www.youtube.com/watch?v=${c.videoId}`,


### PR DESCRIPTION
## Summary
- expose video like counts in the API
- allow sorting by views, like ratio or duration
- add slider-based filters for like ratio, likes range and video length

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a77e105a608325aec64501c14fa943